### PR TITLE
增加对完整路径的regex匹配

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,11 @@ def dfs_search_files(share_key: str, path="/"):
             mat = re.match(args.file.replace('*', '.*'), obj['file_name'])
             if mat is not None and mat.span()[1] == len(obj['file_name']):
                 filelist.append(obj)
+                continue
+            mat = re.match(args.file.replace('*', '.*'), obj['file_path'])
+            if mat is not None and mat.span()[1] == len(obj['file_path']):
+                filelist.append(obj)
+                continue
     return filelist
 
 


### PR DESCRIPTION
之前的regex只匹配文件名，不匹配路径，无法实现下载链接中的某个指定文件夹的功能